### PR TITLE
Update model to use trips instead of only routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,21 @@ is, properties not explicitly marked as optional may not be null.
   firstName: string;
   lastName: string;
   email: string;
-  routes?: Route[];
+  trips?: Trip[];
+}
+```
+
+##### `Trip`
+
+```ts
+{
+  id: number;
+  /**
+   * As a UTC timestamp in the format "yyyy-MM-dd'T'HH:mm:ss'Z'"; e.g.
+   * "2018-09-06T21:45:45Z".
+   */
+  creationDate: string;
+  route: Route;
 }
 ```
 
@@ -92,10 +106,9 @@ is, properties not explicitly marked as optional may not be null.
 ```ts
 {
   id: number;
-  // As a UTC timestamp in the format "yyyy-MM-dd'T'HH:mm:ss'Z'"; e.g.
-  // "2018-09-06T21:45:45Z".
-  creationDate: string;
-  // Always ordered from start to finish.
+  /**
+   * Always ordered from start to finish.
+   */
   legs: Leg[];
 }
 ```
@@ -107,11 +120,17 @@ is, properties not explicitly marked as optional may not be null.
   id: number;
   start: Waypoint;
   end: Waypoint;
-  // In seconds.
+  /**
+   * In seconds.
+   */
   travelTime: number;
-  // In meters.
+  /**
+   * In meters.
+   */
   distance: number;
-  // The zero-based index of this leg, to order it among other legs.
+  /**
+   * The zero-based index of this leg, to order it among other legs.
+   */
   index: number;
 }
 ```
@@ -123,7 +142,9 @@ is, properties not explicitly marked as optional may not be null.
   id: number;
   latitude: number;
   longitude: number;
-  // A user-readable address string.
+  /**
+   * A user-readable address string.
+   */
   address: string;
 }
 ```

--- a/client/src/app/models/route.model.ts
+++ b/client/src/app/models/route.model.ts
@@ -3,11 +3,6 @@ import { Leg } from './leg.model';
 export interface Route {
   id: number;
   /**
-   * As a UTC timestamp in the format "yyyy-MM-dd'T'HH:mm:ss'Z'"; e.g.
-   * "2018-09-06T21:45:45Z".
-   */
-  creationDate: string;
-  /**
    * Always ordered from start to finish.
    */
   legs: Leg[];

--- a/client/src/app/models/trip.model.ts
+++ b/client/src/app/models/trip.model.ts
@@ -1,0 +1,11 @@
+import { Route } from './route.model';
+
+export interface Trip {
+  id: number;
+  /**
+   * As a UTC timestamp in the format "yyyy-MM-dd'T'HH:mm:ss'Z'"; e.g.
+   * "2018-09-06T21:45:45Z".
+   */
+  creationDate: string;
+  route: Route;
+}

--- a/client/src/app/models/user.model.ts
+++ b/client/src/app/models/user.model.ts
@@ -1,4 +1,4 @@
-import { Route } from './route.model';
+import { Trip } from './trip.model';
 
 export interface User {
   id: number;
@@ -6,5 +6,5 @@ export interface User {
   firstName: string;
   lastName: string;
   email: string;
-  routes?: Route[];
+  trips?: Trip[];
 }

--- a/server/src/main/java/com/wayfinder/server/beans/Leg.java
+++ b/server/src/main/java/com/wayfinder/server/beans/Leg.java
@@ -11,8 +11,6 @@ import javax.persistence.SequenceGenerator;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-
 /**
  * A leg is the route between two adjacent waypoints.
  * 

--- a/server/src/main/java/com/wayfinder/server/beans/Route.java
+++ b/server/src/main/java/com/wayfinder/server/beans/Route.java
@@ -1,6 +1,5 @@
 package com.wayfinder.server.beans;
 
-import java.util.Date;
 import java.util.List;
 
 import javax.persistence.CascadeType;
@@ -13,13 +12,9 @@ import javax.persistence.Id;
 import javax.persistence.OneToMany;
 import javax.persistence.OrderBy;
 import javax.persistence.SequenceGenerator;
-import javax.persistence.Temporal;
-import javax.persistence.TemporalType;
 
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
-
-import com.fasterxml.jackson.annotation.JsonFormat;
 
 /**
  * A route is the navigation information for an entire trip, from start to
@@ -39,13 +34,6 @@ public class Route {
 	@GeneratedValue(generator = "seq_route_id", strategy = GenerationType.SEQUENCE)
 	private int id;
 	/**
-	 * The date/time on which the route was created.
-	 */
-	@Column(nullable = false)
-	@Temporal(TemporalType.TIMESTAMP)
-	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss'Z'", timezone = "UTC")
-	private Date creationDate;
-	/**
 	 * The legs which this route contains. The list is guaranteed to be ordered by
 	 * leg index, so that the legs appear in the natural travel order (from start to
 	 * end).
@@ -61,5 +49,13 @@ public class Route {
 
 	public void setId(int id) {
 		this.id = id;
+	}
+
+	public List<Leg> getLegs() {
+		return legs;
+	}
+
+	public void setLegs(List<Leg> legs) {
+		this.legs = legs;
 	}
 }

--- a/server/src/main/java/com/wayfinder/server/beans/Trip.java
+++ b/server/src/main/java/com/wayfinder/server/beans/Trip.java
@@ -1,0 +1,74 @@
+package com.wayfinder.server.beans;
+
+import java.util.Date;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.OneToOne;
+import javax.persistence.SequenceGenerator;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
+
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+/**
+ * A trip consists of the route that the user intends to take, along with other
+ * associated data like the trip checklist and saved points of interest around
+ * waypoints.
+ * 
+ * @author Ian Johnson
+ */
+@Component
+@Scope("prototype")
+@Entity
+public class Trip {
+	/**
+	 * The ID of the trip in the database.
+	 */
+	@Id
+	@SequenceGenerator(name = "seq_trip_id", sequenceName = "seq_trip_id")
+	@GeneratedValue(generator = "seq_trip_id", strategy = GenerationType.SEQUENCE)
+	private int id;
+	/**
+	 * The date/time on which the trip was created.
+	 */
+	@Column(nullable = false)
+	@Temporal(TemporalType.TIMESTAMP)
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss'Z'", timezone = "UTC")
+	private Date creationDate;
+	/**
+	 * The route corresponding to this trip.
+	 */
+	@OneToOne
+	private Route route;
+
+	public int getId() {
+		return id;
+	}
+
+	public void setId(int id) {
+		this.id = id;
+	}
+
+	public Date getCreationDate() {
+		return creationDate;
+	}
+
+	public void setCreationDate(Date creationDate) {
+		this.creationDate = creationDate;
+	}
+
+	public Route getRoute() {
+		return route;
+	}
+
+	public void setRoute(Route route) {
+		this.route = route;
+	}
+}

--- a/server/src/main/java/com/wayfinder/server/beans/User.java
+++ b/server/src/main/java/com/wayfinder/server/beans/User.java
@@ -1,6 +1,6 @@
 package com.wayfinder.server.beans;
 
-import java.util.Set;
+import java.util.List;
 
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
@@ -10,6 +10,7 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.ManyToMany;
+import javax.persistence.OrderBy;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 
@@ -36,7 +37,7 @@ public class User {
 	@Column(nullable = false)
 	@JsonIgnore
 	private byte[] passwordHash;
-	
+
 	@Column(nullable = false)
 	@JsonIgnore
 	private byte[] passwordSalt;
@@ -50,8 +51,13 @@ public class User {
 	@Column(nullable = false)
 	private String email;
 
+	/**
+	 * The user's trips. This list is always in descending order of creation
+	 * date/time.
+	 */
 	@ManyToMany(fetch = FetchType.EAGER, cascade = CascadeType.ALL)
-	private Set<Route> routes;
+	@OrderBy("creationDate")
+	private List<Trip> trips;
 
 	public User() {
 	}
@@ -112,11 +118,11 @@ public class User {
 		this.email = email;
 	}
 
-	public Set<Route> getRoutes() {
-		return routes;
+	public List<Trip> getTrips() {
+		return trips;
 	}
 
-	public void setRoutes(Set<Route> routes) {
-		this.routes = routes;
+	public void setTrips(List<Trip> trips) {
+		this.trips = trips;
 	}
 }


### PR DESCRIPTION
A user has several trips, each of which contains the route associated with that trip. The difference is that later, we will be adding other data to a trip (checklist, POIs, etc.), so this is just getting a head-start on that abstraction.