### PR TITLE
Fix Angular HTTPInterceptors

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,10 +105,29 @@ Type definitions are given here in TypeScript notation. The definitions
 should be interpreted as if written using TypeScripts `strict` option; that
 is, properties not explicitly marked as optional may not be null.
 
+##### `ApiErrorType` (enum)
+
+```ts
+{
+  /**
+   * The user is not logged in.
+   */
+  NotLoggedIn = 'NOT_LOGGED_IN',
+  /**
+   * The user is logged in, but does not have permission to access an endpoint.
+   */
+  Unauthorized = 'UNAUTHORIZED',
+}
+```
+
 ##### `ApiError`
 
 ```ts
 {
+  /**
+   * The type of the error, if a specific type can be associated.
+   */
+  type?: ApiErrorType;
   /**
    * The primary message describing the error.
    */

--- a/client/src/app/app.module.ts
+++ b/client/src/app/app.module.ts
@@ -1,5 +1,3 @@
-/// <reference types="@types/googlemaps" />
-
 import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
@@ -15,7 +13,9 @@ import { NavbarComponent } from './components/navbar/navbar.component';
 import { AgmDirectionModule } from 'agm-direction';
 import { AppRoutingModule } from './app-routing/app-routing.module';
 import { HomeComponent } from './components/home/home.component';
-import { HttpClientModule } from '@angular/common/http';
+import { HttpClientModule, HTTP_INTERCEPTORS } from '@angular/common/http';
+import { JwtInterceptor } from './utils/jwt.interceptor';
+import { ErrorInterceptor } from './utils/error.interceptor';
 
 @NgModule({
   declarations: [
@@ -24,21 +24,34 @@ import { HttpClientModule } from '@angular/common/http';
     MapComponent,
     NavbarComponent,
     HomeComponent,
-    UserpageComponent
+    UserpageComponent,
   ],
   imports: [
-    AgmCoreModule.forRoot({ apiKey: 'AIzaSyBrZkV0T-ZJncle1r0SqiwQ2MJB6Qxz3mU', libraries: ['places'] }),
+    AgmCoreModule.forRoot({
+      apiKey: 'AIzaSyBrZkV0T-ZJncle1r0SqiwQ2MJB6Qxz3mU',
+      libraries: ['places'],
+    }),
     BrowserModule,
     HttpClientModule,
     FormsModule,
     AgmDirectionModule,
     NgbModule.forRoot(),
     AppRoutingModule,
-    HttpClientModule
+    HttpClientModule,
   ],
   providers: [
-    GoogleMapsAPIWrapper
+    {
+      provide: HTTP_INTERCEPTORS,
+      useClass: JwtInterceptor,
+      multi: true,
+    },
+    {
+      provide: HTTP_INTERCEPTORS,
+      useClass: ErrorInterceptor,
+      multi: true,
+    },
+    GoogleMapsAPIWrapper,
   ],
-  bootstrap: [AppComponent]
+  bootstrap: [AppComponent],
 })
-export class AppModule { }
+export class AppModule {}

--- a/client/src/app/models/api-error.model.ts
+++ b/client/src/app/models/api-error.model.ts
@@ -17,6 +17,11 @@ export enum ApiErrorType {
  */
 export interface ApiError {
   /**
+   * The HTTP status that accompanied the error. This is not returned by the
+   * API, but is provided as a convenience by the ErrorInterceptor.
+   */
+  status: number;
+  /**
    * The type of the error, if a specific type can be associated.
    */
   type?: ApiErrorType;

--- a/client/src/app/models/api-error.model.ts
+++ b/client/src/app/models/api-error.model.ts
@@ -1,7 +1,25 @@
 /**
+ * A specific type of error which can be returned by the API.
+ */
+export enum ApiErrorType {
+  /**
+   * The user is not logged in.
+   */
+  NotLoggedIn = 'NOT_LOGGED_IN',
+  /**
+   * The user is logged in, but does not have permission to access an endpoint.
+   */
+  Unauthorized = 'UNAUTHORIZED',
+}
+
+/**
  * An error returned from the backend API.
  */
 export interface ApiError {
+  /**
+   * The type of the error, if a specific type can be associated.
+   */
+  type?: ApiErrorType;
   /**
    * The primary message describing the error.
    */

--- a/client/src/app/utils/error.interceptor.ts
+++ b/client/src/app/utils/error.interceptor.ts
@@ -1,25 +1,44 @@
 import { Injectable } from '@angular/core';
-import { HttpRequest, HttpHandler, HttpEvent, HttpInterceptor } from '@angular/common/http';
+import {
+  HttpRequest,
+  HttpHandler,
+  HttpEvent,
+  HttpInterceptor,
+  HttpErrorResponse,
+} from '@angular/common/http';
+import { Router } from '@angular/router';
 import { Observable, throwError } from 'rxjs';
 import { catchError } from 'rxjs/operators';
+
+import { ApiError, ApiErrorType } from '../models/api-error.model';
 import { AuthService } from '../services/auth/auth.service';
 
-@Injectable({
-  providedIn: 'root'
-})
+@Injectable()
 export class ErrorInterceptor implements HttpInterceptor {
-  constructor(private authService: AuthService) { }
+  constructor(private authService: AuthService, private router: Router) {}
 
-  intercept(request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
-    return next.handle(request).pipe(catchError(err => {
-      if (err.status === 403) {
-        // auto logout if 403 response returned from api
-        this.authService.logout();
-        location.reload(true);
-      }
-
-      const error = err.error.message || err.statusText;
-      return throwError(error);
-    }));
+  intercept(
+    request: HttpRequest<any>,
+    next: HttpHandler
+  ): Observable<HttpEvent<any>> {
+    return next.handle(request).pipe(
+      catchError((err: HttpErrorResponse) => {
+        if (err.error instanceof ErrorEvent) {
+          // A client-side or network error occurred.
+          console.error('Network error:', err.error);
+          return throwError(err.error);
+        } else {
+          // API error.
+          const apiError = <ApiError>err.error;
+          apiError.status = err.status;
+          // Automatically log out if the error was due to being not logged in.
+          if (apiError.type === ApiErrorType.NotLoggedIn) {
+            this.authService.logout();
+            this.router.navigate(['login']);
+          }
+          return throwError(apiError);
+        }
+      })
+    );
   }
 }

--- a/client/src/app/utils/jwt.interceptor.ts
+++ b/client/src/app/utils/jwt.interceptor.ts
@@ -1,23 +1,27 @@
 import { Injectable } from '@angular/core';
-import { HttpRequest, HttpHandler, HttpEvent, HttpInterceptor, HttpErrorResponse } from '@angular/common/http';
+import {
+  HttpRequest,
+  HttpHandler,
+  HttpEvent,
+  HttpInterceptor,
+} from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { TokenStorage } from './token.storage';
-import { Router } from '@angular/router';
 
-@Injectable({
-  providedIn: 'root'
-})
+@Injectable()
 export class JwtInterceptor implements HttpInterceptor {
+  constructor(private tokenStorage: TokenStorage) {}
 
-  constructor(private tokenStorage: TokenStorage, private router: Router) { }
-
-  intercept(request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
+  intercept(
+    request: HttpRequest<any>,
+    next: HttpHandler
+  ): Observable<HttpEvent<any>> {
     const token = this.tokenStorage.getToken();
     if (token != null) {
       request = request.clone({
         setHeaders: {
-          Authorization: `Bearer ${token}`
-        }
+          Authorization: `Bearer ${token}`,
+        },
       });
     }
     return next.handle(request);

--- a/client/src/tsconfig.app.json
+++ b/client/src/tsconfig.app.json
@@ -2,10 +2,7 @@
   "extends": "../tsconfig.json",
   "compilerOptions": {
     "outDir": "../out-tsc/app",
-    "types": []
+    "types": ["@types/googlemaps"]
   },
-  "exclude": [
-    "test.ts",
-    "**/*.spec.ts"
-  ]
+  "exclude": ["test.ts", "**/*.spec.ts"]
 }

--- a/client/src/tsconfig.spec.json
+++ b/client/src/tsconfig.spec.json
@@ -2,17 +2,8 @@
   "extends": "../tsconfig.json",
   "compilerOptions": {
     "outDir": "../out-tsc/spec",
-    "types": [
-      "jasmine",
-      "node"
-    ]
+    "types": ["jasmine", "node", "@types/googlemaps"]
   },
-  "files": [
-    "test.ts",
-    "polyfills.ts"
-  ],
-  "include": [
-    "**/*.spec.ts",
-    "**/*.d.ts"
-  ]
+  "files": ["test.ts", "polyfills.ts"],
+  "include": ["**/*.spec.ts", "**/*.d.ts"]
 }

--- a/server/src/main/java/com/wayfinder/server/beans/ResponseError.java
+++ b/server/src/main/java/com/wayfinder/server/beans/ResponseError.java
@@ -13,6 +13,10 @@ import org.springframework.http.ResponseEntity;
  */
 public class ResponseError {
 	/**
+	 * The type of the error, if it can be associated with a specific type.
+	 */
+	private Type type;
+	/**
 	 * The primary message describing the error.
 	 */
 	private String message;
@@ -21,20 +25,44 @@ public class ResponseError {
 	 */
 	private List<String> details = new ArrayList<>();
 
+	/**
+	 * A predefined error type.
+	 * 
+	 * @author Ian Johnson
+	 */
+	public enum Type {
+		/**
+		 * The user is not logged in.
+		 */
+		NOT_LOGGED_IN,
+		/**
+		 * The user is logged in, but does not have permission to access an endpoint.
+		 */
+		UNAUTHORIZED,
+	}
+
 	public ResponseError() {
 	}
 
 	public ResponseError(String message) {
 		this.message = message;
 	}
-	
+
 	public ResponseError(String message, List<String> details) {
 		this(message);
 		this.details = details;
 	}
-	
+
 	public ResponseError(Exception e) {
 		this(e.getMessage());
+	}
+
+	public Type getType() {
+		return type;
+	}
+
+	public void setType(Type type) {
+		this.type = type;
 	}
 
 	public String getMessage() {
@@ -51,6 +79,17 @@ public class ResponseError {
 
 	public void setDetails(List<String> details) {
 		this.details = details;
+	}
+
+	/**
+	 * A convenience method for setting the type in a builder-like fashion.
+	 * 
+	 * @param type the new type of the error
+	 * @return <code>this</code>
+	 */
+	public ResponseError withType(Type type) {
+		setType(type);
+		return this;
 	}
 
 	/**

--- a/server/src/main/java/com/wayfinder/server/controllers/ErrorController.java
+++ b/server/src/main/java/com/wayfinder/server/controllers/ErrorController.java
@@ -1,15 +1,22 @@
 package com.wayfinder.server.controllers;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
@@ -17,6 +24,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.wayfinder.server.beans.ResponseError;
 
 /**
@@ -28,7 +36,7 @@ import com.wayfinder.server.beans.ResponseError;
 @RestController
 @ControllerAdvice
 @RequestMapping("/error")
-public class ErrorController {
+public class ErrorController implements AccessDeniedHandler, AuthenticationEntryPoint {
 	private static final Logger logger = LogManager.getLogger();
 
 	// TODO: update Spring to 4.3 or later and use @RequestAttribute to get the
@@ -55,7 +63,7 @@ public class ErrorController {
 				.collect(Collectors.toList());
 		return new ResponseError("Input validation failed.", details).toEntity(HttpStatus.BAD_REQUEST);
 	}
-	
+
 	/**
 	 * Handles the exception thrown when a request body cannot be read.
 	 */
@@ -64,9 +72,42 @@ public class ErrorController {
 		return new ResponseError("Invalid request body format.").toEntity(HttpStatus.BAD_REQUEST);
 	}
 
+	/**
+	 * Handles the exception thrown when access is denied to an endpoint.
+	 */
+	@ExceptionHandler(AccessDeniedException.class)
+	public ResponseEntity<ResponseError> handleException(AccessDeniedException e) {
+		return new ResponseError(e).withType(ResponseError.Type.UNAUTHORIZED).toEntity(HttpStatus.FORBIDDEN);
+	}
+
+	/**
+	 * Handles the exception thrown when a user attempts to access an endpoint
+	 * without being logged in.
+	 */
+	@ExceptionHandler(AuthenticationException.class)
+	public ResponseEntity<ResponseError> handleException(AuthenticationException e) {
+		return new ResponseError(e).withType(ResponseError.Type.NOT_LOGGED_IN).toEntity(HttpStatus.FORBIDDEN);
+	}
+
 	@ExceptionHandler
 	public ResponseEntity<ResponseError> handleException(Exception e) {
 		logger.error("Handling unexpected exception.", e);
 		return new ResponseError("An unexpected error occurred.").toEntity(HttpStatus.INTERNAL_SERVER_ERROR);
+	}
+
+	@Override
+	public void handle(HttpServletRequest request, HttpServletResponse response,
+			AccessDeniedException accessDeniedException) throws IOException, ServletException {
+		ResponseEntity<ResponseError> error = handleException(accessDeniedException);
+		response.setStatus(error.getStatusCode().value());
+		new ObjectMapper().writeValue(response.getWriter(), error.getBody());
+	}
+
+	@Override
+	public void commence(HttpServletRequest request, HttpServletResponse response,
+			AuthenticationException authException) throws IOException, ServletException {
+		ResponseEntity<ResponseError> error = handleException(authException);
+		response.setStatus(error.getStatusCode().value());
+		new ObjectMapper().writeValue(response.getWriter(), error.getBody());
 	}
 }

--- a/server/src/main/java/com/wayfinder/server/security/WebSecurityConfig.java
+++ b/server/src/main/java/com/wayfinder/server/security/WebSecurityConfig.java
@@ -10,6 +10,8 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.security.web.util.matcher.RequestMatcher;
 
+import com.wayfinder.server.controllers.ErrorController;
+
 /**
  * A configuration class for web security, which sets up the JwtTokenFilter.
  * 
@@ -20,6 +22,8 @@ import org.springframework.security.web.util.matcher.RequestMatcher;
 public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 	@Autowired
 	private JwtTokenProvider tokenProvider;
+	@Autowired
+	private ErrorController errorController;
 
 	@Override
 	protected void configure(HttpSecurity http) throws Exception {
@@ -31,5 +35,6 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 		http.authorizeRequests().requestMatchers(allowable).permitAll().anyRequest().authenticated();
 		http.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);
 		http.addFilterBefore(new JwtTokenFilter(tokenProvider), UsernamePasswordAuthenticationFilter.class);
+		http.exceptionHandling().accessDeniedHandler(errorController).authenticationEntryPoint(errorController);
 	}
 }


### PR DESCRIPTION
The HTTPInterceptors weren't registered before, and also the "auto-logout" functionality was a little brittle, so this fixes both of those problems. This PR also adds additional information to API errors in certain circumstances, including when authorization fails.

There's also a bit of miscellaneous cleanup in the Angular code, which probably should have been a separate PR, but oh well.