### PR TITLE
Update schema, making IDs optional on the client

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ is, properties not explicitly marked as optional may not be null.
 
 ```ts
 {
-  id: number;
+  id?: number;
   username: string;
   firstName: string;
   lastName: string;
@@ -156,7 +156,7 @@ is, properties not explicitly marked as optional may not be null.
 
 ```ts
 {
-  id: number;
+  id?: number;
   /**
    * As a UTC timestamp in the format "yyyy-MM-dd'T'HH:mm:ss'Z'"; e.g.
    * "2018-09-06T21:45:45Z".
@@ -175,7 +175,7 @@ is, properties not explicitly marked as optional may not be null.
 
 ```ts
 {
-  id: number;
+  id?: number;
   /**
    * Always ordered from start to finish.
    */
@@ -187,7 +187,7 @@ is, properties not explicitly marked as optional may not be null.
 
 ```ts
 {
-  id: number;
+  id?: number;
   start: Waypoint;
   end: Waypoint;
   /**
@@ -205,13 +205,13 @@ is, properties not explicitly marked as optional may not be null.
 
 ```ts
 {
-  id: number;
+  id?: number;
   latitude: number;
   longitude: number;
   /**
    * A user-readable address string.
    */
-  address: string;
+  address?: string;
   /**
    * The place ID, as defined by Google.
    */

--- a/client/src/app/models/leg.model.ts
+++ b/client/src/app/models/leg.model.ts
@@ -1,7 +1,7 @@
 import { Waypoint } from './waypoint.model';
 
 export interface Leg {
-  id: number;
+  id?: number;
   start: Waypoint;
   end: Waypoint;
   /**

--- a/client/src/app/models/route.model.ts
+++ b/client/src/app/models/route.model.ts
@@ -1,7 +1,7 @@
 import { Leg } from './leg.model';
 
 export interface Route {
-  id: number;
+  id?: number;
   /**
    * Always ordered from start to finish.
    */

--- a/client/src/app/models/trip.model.ts
+++ b/client/src/app/models/trip.model.ts
@@ -2,7 +2,7 @@ import { Route } from './route.model';
 import { AnnotatedWaypoint } from './annotated-waypoint.model';
 
 export interface Trip {
-  id: number;
+  id?: number;
   /**
    * As a UTC timestamp in the format "yyyy-MM-dd'T'HH:mm:ss'Z'"; e.g.
    * "2018-09-06T21:45:45Z".

--- a/client/src/app/models/user.model.ts
+++ b/client/src/app/models/user.model.ts
@@ -1,7 +1,7 @@
 import { Trip } from './trip.model';
 
 export interface User {
-  id: number;
+  id?: number;
   username: string;
   firstName: string;
   lastName: string;
@@ -13,4 +13,4 @@ export interface User {
  * New users can omit certain "required" properties which will be provided by
  * default or by the backend.
  */
-export type NewUser = Overwrite<User, { id?: number, trips?: Trip[] }>;
+export type NewUser = Overwrite<User, { trips?: Trip[] }>;

--- a/client/src/app/models/waypoint.model.ts
+++ b/client/src/app/models/waypoint.model.ts
@@ -1,11 +1,11 @@
 export interface Waypoint {
-  id: number;
+  id?: number;
   latitude: number;
   longitude: number;
   /**
    * A user-readable address string.
    */
-  address: string;
+  address?: string;
   /**
    * The place ID, as defined by Google.
    */

--- a/client/src/app/services/user/user.service.ts
+++ b/client/src/app/services/user/user.service.ts
@@ -74,9 +74,10 @@ export class UserService {
   /**
    * Updates the given user.
    *
-   * @param user the user to update
+   * @param user the user to update. The ID property is required, to identify
+   * the user to update.
    */
-  update(user: User): Observable<User> {
+  update(user: Overwrite<User, { id: number }>): Observable<User> {
     return this.http
       .put<User>(environment.apiUrl + `/users/${user.id}`, user)
       .pipe(

--- a/server/src/main/java/com/wayfinder/server/beans/Waypoint.java
+++ b/server/src/main/java/com/wayfinder/server/beans/Waypoint.java
@@ -7,7 +7,6 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.SequenceGenerator;
 
-import org.hibernate.validator.constraints.NotEmpty;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 
@@ -42,7 +41,6 @@ public class Waypoint {
 	 * The address of the waypoint, as a user-readable string.
 	 */
 	@Column(nullable = false)
-	@NotEmpty
 	private String address;
 	/**
 	 * The (optional) place ID, as defined by Google.


### PR DESCRIPTION
This PR makes the ID properties optional on the front-end models, and makes the waypoint address property optional on both ends.